### PR TITLE
Keeping one unit after board reset implemented

### DIFF
--- a/client/src/main/scala/ClientMain.scala
+++ b/client/src/main/scala/ClientMain.scala
@@ -379,8 +379,8 @@ class Client() {
         serverActionSequence(boardIdx) = Vector()
         resetLocalBoards(boardIdx)
 
-      case Protocol.ReportResetBoard(boardIdx,necroNames, canMove, reinforcements) =>
-        serverBoards(boardIdx).resetBoard(necroNames, canMove, reinforcements)
+      case Protocol.ReportResetBoard(boardIdx,necroNames, canMoveFirstTurn, turnEndingImmediatelyAfterReset, reinforcements) =>
+        serverBoards(boardIdx).resetBoard(necroNames, canMoveFirstTurn, turnEndingImmediatelyAfterReset, reinforcements)
         resetLocalBoards(boardIdx)
 
       case Protocol.ReportNewTurn(newSide) =>

--- a/client/src/main/scala/Drawing.scala
+++ b/client/src/main/scala/Drawing.scala
@@ -881,6 +881,24 @@ object Drawing {
 
       fillHex(hexLoc, fillColor, techScale, alpha=alpha)
       strokeHex(hexLoc, strokeColor, techScale, lineWidth=2.0, alpha=alpha)
+    }
+    for(i <- 0 until game.techLine.length) {
+      val techState = game.techLine(i)
+      val hexLoc = techLocs(i)
+      techState.tech match {
+        case PieceTech(pieceName) =>
+          if(board.canFreeBuyPiece(game.curSide,pieceName)) {
+            fillHex(hexLoc, "#ffee77", techScale, alpha=0.8)
+            strokeHex(hexLoc, "#ffdd11", techScale, lineWidth=4.0, alpha=0.8)
+          }
+        case _ => ()
+      }
+    }
+    for(i <- 0 until game.techLine.length) {
+      val techState = game.techLine(i)
+      val hexLoc = techLocs(i)
+      val changedThisTurn = Side.exists { side => techState.startingLevelThisTurn(side) != techState.level(side) }
+      val alpha = if(changedThisTurn) 0.5 else 1.0
 
       text(techState.shortDisplayName, PixelLoc.ofHexLoc(hexLoc, gridSize), "black", alpha=alpha)
       techState.techNumber.foreach { techNumber =>
@@ -1288,7 +1306,7 @@ object Drawing {
 
     def highlightUndoneGeneralAction(action: GeneralBoardAction): Unit = {
       action match {
-        case BuyReinforcement(pieceName) =>
+        case BuyReinforcement(pieceName,_) =>
           ui.Reinforcements.getHexLocsAndContents(board.side,board).foreach { case (hexLoc,name,_) =>
             if(name == pieceName)
               strokeHex(hexLoc, "black", tileScale, alpha=0.5)

--- a/client/src/main/scala/Mouse.scala
+++ b/client/src/main/scala/Mouse.scala
@@ -511,21 +511,48 @@ case class NormalMouseMode(val mouseState: MouseState) extends MouseMode {
                     mouseState.client.doGameAction(UnsellTech(game.curSide))
                 }
               case _ =>
-                mouseState.client.doGameAction(UndoTech(game.curSide,techIdx))
+                if(techState.level(game.curSide) != techState.startingLevelThisTurn(game.curSide)) {
+                  mouseState.client.doGameAction(UndoTech(game.curSide,techIdx))
+                }
+                else {
+                  //Possibly attempt to undo any free-bought piece, just in case somehow we free-bought a piece
+                  //that we don't have tech for
+                  techState.tech match {
+                    case PieceTech(pieceName) =>
+                      if(board.couldFreeBuyPieceThisTurn(game.curSide,pieceName))
+                        mouseState.client.doActionOnCurBoard(BuyReinforcementUndo(pieceName,makeActionId()))
+                    case _ => ()
+                  }
+                }
             }
           }
           else {
-            techState.level(game.curSide) match {
-              case TechLocked | TechUnlocked =>
-                mouseState.client.doGameAction(PerformTech(game.curSide,techIdx))
-              case TechAcquired =>
-                techState.tech match {
-                  case PieceTech(pieceName) =>
-                    mouseState.client.doActionOnCurBoard(DoGeneralBoardAction(BuyReinforcement(pieceName),makeActionId()))
-                  case Copycat | Metamagic => ()
-                  case TechSeller =>
-                    mouseState.client.doGameAction(SellTech(game.curSide))
+            val freeBuyingPiece: Option[PieceName] = {
+              techState.tech match {
+                case PieceTech(pieceName) =>
+                  if(board.canFreeBuyPiece(game.curSide,pieceName))
+                    Some(pieceName)
+                  else
+                    None
+                case _ => None
+              }
+            }
+            freeBuyingPiece match {
+              case Some(pieceName) =>
+                mouseState.client.doActionOnCurBoard(DoGeneralBoardAction(BuyReinforcement(pieceName,free=true),makeActionId()))
+              case None =>
+                techState.level(game.curSide) match {
+                  case TechLocked | TechUnlocked =>
+                    mouseState.client.doGameAction(PerformTech(game.curSide,techIdx))
+                  case TechAcquired =>
+                    techState.tech match {
+                      case PieceTech(pieceName) =>
+                        mouseState.client.doActionOnCurBoard(DoGeneralBoardAction(BuyReinforcement(pieceName,free=false),makeActionId()))
+                      case Copycat | Metamagic => ()
+                      case TechSeller =>
+                        mouseState.client.doGameAction(SellTech(game.curSide))
 
+                    }
                 }
             }
           }

--- a/core/src/main/scala/Board.scala
+++ b/core/src/main/scala/Board.scala
@@ -502,9 +502,9 @@ case class Board private (
   }
 
   //Reset the board to the starting position
-  def resetBoard(necroNames: SideArray[PieceName], canMove: Boolean, reinforcements: SideArray[Map[PieceName, Int]]): Unit = {
+  def resetBoard(necroNames: SideArray[PieceName], canMoveFirstTurn: Boolean, turnEndingImmediatelyAfterReset: Boolean, reinforcements: SideArray[Map[PieceName, Int]]): Unit = {
     initialStateThisTurn = history.spawnState.copy()
-    initialStateThisTurn.resetBoard(necroNames, canMove, reinforcements)
+    initialStateThisTurn.resetBoard(necroNames, canMoveFirstTurn, turnEndingImmediatelyAfterReset, reinforcements)
     actionsThisTurn = Vector()
     //TODO loses history information for recording purposes into playerGeneralBoardActionsPrevTurns
     //on endTurn()

--- a/core/src/main/scala/BoardState.scala
+++ b/core/src/main/scala/BoardState.scala
@@ -662,8 +662,9 @@ case class BoardState private (
     unsummonedThisTurn = Nil
     hasUsedSpawnerTile = false
 
-    //Gain any free pieces we're supposed to
-    gainStartOfTurnReinforcements()
+    //Gain any free pieces we're supposed to, but only on turns we can actually play
+    if(!turnEndingImmediately && canMove)
+      gainStartOfTurnReinforcements()
 
     //Check for win conditions - start of turn at least 8 graveyards
     var startNumGraveyards = 0

--- a/core/src/main/scala/Protocol.scala
+++ b/core/src/main/scala/Protocol.scala
@@ -23,7 +23,7 @@ object Protocol {
   case class ReportBoardAction(boardIdx: Int, boardAction: BoardAction, newBoardSequence: Int) extends Response
   case class ReportGameAction(gameAction: GameAction, newGameSequence: Int) extends Response
   case class ReportNewTurn(newSide: Side) extends Response
-  case class ReportResetBoard(boardIdx: Int, necroNames:SideArray[PieceName], canMove: Boolean, reinforcements: SideArray[Map[PieceName, Int]]) extends Response
+  case class ReportResetBoard(boardIdx: Int, necroNames:SideArray[PieceName], canMoveFirstTurn: Boolean, turnEndingImmediatelyAfterReset: Boolean, reinforcements: SideArray[Map[PieceName, Int]]) extends Response
   case class ReportRevealSpells(spellsIdsAndNames: Array[(Int,SpellName)]) extends Response
   case class ReportTimeLeft(timeLeft: Double) extends Response
   case class ReportPause(isPaused:Boolean) extends Response

--- a/core/src/main/scala/Units.scala
+++ b/core/src/main/scala/Units.scala
@@ -615,6 +615,13 @@ object Units {
     shadowlord
   )
 
+  //Given a piece, get its index within the pieces array
+  val allPiecesIdx: Map[PieceName,Int] =
+    pieces.zipWithIndex.groupBy { case (piece,_) => piece.name }.mapValues { grouped =>
+      assert(grouped.length == 1)
+      grouped.head._2
+    }
+
   //Generally, we store and send the PieceName everywhere in the protocol, since unlike a PieceStats it's easily serialized.
   //This is the global map that everything uses to look up the stats again from the name.
   val pieceMap: Map[PieceName,PieceStats] = pieces.groupBy(piece => piece.name).mapValues { pieces =>

--- a/server/src/main/scala/AI.scala
+++ b/server/src/main/scala/AI.scala
@@ -69,8 +69,13 @@ private class AIActor(out: ActorRef, game: GameState, doTutorial: Boolean) exten
         var keepBuying = true
         while(keepBuying && !unlockedUnits.isEmpty) {
           val chosenUnit = unlockedUnits(aiRand.nextInt(unlockedUnits.length))
-          if(game.game.souls(S1) >= chosenUnit.cost) {
-            out ! Protocol.DoBoardAction(0, DoGeneralBoardAction(BuyReinforcement(chosenUnit.name), makeActionId()))
+          if(game.boards(0).curState.canFreeBuyPiece(S1,chosenUnit.name)) {
+            out ! Protocol.DoBoardAction(0, DoGeneralBoardAction(BuyReinforcement(chosenUnit.name,free=true), makeActionId()))
+            Thread.sleep(100)
+            keepBuying = true
+          }
+          else if(game.game.souls(S1) >= chosenUnit.cost) {
+            out ! Protocol.DoBoardAction(0, DoGeneralBoardAction(BuyReinforcement(chosenUnit.name,free=false), makeActionId()))
             Thread.sleep(100)
             keepBuying = true
           } else {

--- a/server/src/main/scala/GameState.scala
+++ b/server/src/main/scala/GameState.scala
@@ -283,6 +283,7 @@ case class GameState (
 
     game.endTurn()
     boards.foreach { board => board.endTurn() }
+    broadcastAll(Protocol.ReportNewTurn(newSide))
 
     refillUpcomingSpells()
 
@@ -298,7 +299,6 @@ case class GameState (
         }
       }
     }
-    broadcastAll(Protocol.ReportNewTurn(newSide))
 
     //Schedule the next end of turn
     game.winner match {

--- a/server/src/main/scala/GameState.scala
+++ b/server/src/main/scala/GameState.scala
@@ -141,7 +141,7 @@ case class GameState (
     }
   }
 
-  private def doResetBoard(boardIdx: Int, canMove: Boolean): Unit = {
+  private def doResetBoard(boardIdx: Int, canMoveFirstTurn: Boolean): Unit = {
     // TODO: Another matter is how exactly you get your advanced Necromancer. The draw 3 choose 1 system is what we're using now, but large numbers of boards + Swarm being active can cause weird edge cases here (in 4 boards with a Swarm active, you only have your old Captain left to choose, rather degenerately)
     // TODO: Pick a unit to keep on reset
     Side.foreach { side =>
@@ -152,20 +152,9 @@ case class GameState (
     Side.foreach { side =>
       specialNecrosRemaining(side) = specialNecrosRemaining(side).tail
     }
-    val reinforcements = SideArray.createFn({ side =>
-        val unlocked_initiate =
-          game.piecesAcquired(side).get(Units.initiate.name) match {
-            case None => false
-            case Some(techState) => techState.level(side) == TechAcquired
-          }
-        if(unlocked_initiate) {
-          Map(Units.initiate.name -> 1)
-        } else {
-          Map(Units.acolyte.name -> 1)
-        }
-    })
-    boards(boardIdx).resetBoard(necroNames, canMove, reinforcements)
-    broadcastAll(Protocol.ReportResetBoard(boardIdx,necroNames, canMove, reinforcements))
+    val reinforcements = SideArray.create(Map())
+    boards(boardIdx).resetBoard(necroNames, canMoveFirstTurn, reinforcements)
+    broadcastAll(Protocol.ReportResetBoard(boardIdx,necroNames, canMoveFirstTurn, reinforcements))
   }
 
   private def maybeDoEndOfTurn(scheduleEndOfTurn: ScheduleReason => Unit): Unit = {
@@ -244,12 +233,13 @@ case class GameState (
     }
 
     //Check win condition and reset boards as needed
+    //This happens BEFORE ending the turn so that the winner doesn't get all the souls on the won board.
     for(boardIdx <- 0 until boards.length) {
       val board = boards(boardIdx)
       if(board.curState.hasWon) {
         doAddWin(oldSide,boardIdx)
         if(game.winner.isEmpty) {
-          doResetBoard(boardIdx, true)
+          doResetBoard(boardIdx, canMoveFirstTurn = true)
         }
       }
     }
@@ -302,7 +292,7 @@ case class GameState (
         if(game.winner.isEmpty) {
           doAddWin(newSide,boardIdx)
           if(game.winner.isEmpty) {
-            doResetBoard(boardIdx, false)
+            doResetBoard(boardIdx, canMoveFirstTurn = false)
           }
         }
       }
@@ -463,7 +453,7 @@ case class GameState (
                   //Check ahead of time if it's legal
                   game.tryIsLegal(gameAction).map { case () =>
                     //And if so, reset the board
-                    doResetBoard(boardIdx, true)
+                    doResetBoard(boardIdx, canMoveFirstTurn = true)
                     allMessages = allMessages :+ ("GAME: Team " + game.curSide.toColorName + " resigned board " + (boardIdx+1) + "!")
                     broadcastMessages()
                   }


### PR DESCRIPTION
It's implemented as a "free buy" of any of the units you had before the reset:
* On-board
* In reinforcements 
* Available as a free buy already (silly corner case for a double reset)

Tech line will highlight gold for any free-buyable units, click to do it.

There's a bit of optionality that might not exist in real life minions: you only have to pick what unit you want on your turn. So the player who is taking the second turn after the reset will be able to choose what unit they want to keep in response to seeing the first player's turn. Adding extra alternations in between would be quite awkward with the current code so hoping this is good enough.

