### PR TITLE
Don't check if target location is empty for stumble.

### DIFF
--- a/core/src/main/scala/Spells.scala
+++ b/core/src/main/scala/Spells.scala
@@ -265,7 +265,6 @@ case object Spells {
       if(piece.side == side || piece.baseStats.isNecromancer) Failure(new Exception("Can only target enemy minions"))
       else if(piece.damage <= 0) Failure(new Exception("Can only target damaged pieces"))
       else if(board.topology.distance(loc,piece.loc) != 1) Failure(new Exception("Location is not adjacent"))
-      else if(board.pieces(loc).nonEmpty) Failure(new Exception("Adjacent location is not empty"))
       else board.tryCanEndOnLoc(side, piece.spec, piece.baseStats, piece.curStats(board), loc, List())
     ),
     effect = { (board: BoardState, piece: Piece, loc: Loc) =>


### PR DESCRIPTION
Doesn't work well with swarm. tryCanEndOnLoc handles everything anyway.

Resolves https://github.com/jonathanpaulson/minions/issues/53

Untested :(